### PR TITLE
Run validation with multiple Terraform versions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,19 +2,39 @@ name: Validate
 
 on: push
 
-env:
-  AWS_REGION: local
-
 jobs:
-  validate:
+  validate_terraform_versions:
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        terraform_version:
+          - "0.15.5"
+          - "1.0.11"
+          - "1.1.9"
+          - "1.2.2"
+
+    defaults:
+      run:
+        working-directory: _test
+
     runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: _test
     steps:
       - uses: actions/checkout@v3
-      - uses: hashicorp/setup-terraform@v2.0.0
+      - uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 0.15.5
+          terraform_version:  ${{ matrix.terraform_version }}
       - run: terraform init
       - run: terraform validate
+
+  validate: # this is a workaround, see https://github.community/t/status-check-for-a-matrix-jobs/127354/6
+    if: ${{ always() }}
+    needs: [validate_terraform_versions]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check build status of all needed jobs
+        if: ${{ needs.validate_terraform_versions.result != 'success' }}
+        run: exit 1

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version:  ${{ matrix.terraform_version }}
+          terraform_version: ${{ matrix.terraform_version }}
       - run: terraform init
       - run: terraform validate
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,7 +18,6 @@ jobs:
       run:
         working-directory: _test
 
-    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: _test

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,9 +18,6 @@ jobs:
       run:
         working-directory: _test
 
-    defaults:
-      run:
-        working-directory: _test
     steps:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/_test/.terraform
+/_test/.terraform.lock.hcl

--- a/_test/providers.tf
+++ b/_test/providers.tf
@@ -1,7 +1,9 @@
 provider "aws" {
-  alias = "primary"
+  alias  = "primary"
+  region = "local-1"
 }
 
 provider "aws" {
-  alias = "secondary"
+  alias  = "secondary"
+  region = "local-2"
 }


### PR DESCRIPTION
It's always the currently latest patch version for a minor version.