### PR TITLE
Relax version constraints for test modules

### DIFF
--- a/_test/versions.tf
+++ b/_test/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = ">= 4.0"
     }
   }
   required_version = ">= 0.15.0"


### PR DESCRIPTION
Follow-up of https://github.com/babbel/terraform-aws-s3-bucket-with-cross-region-replication/pull/8