### PR TITLE
Add support for resource-specific tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,6 @@ module "s3-backups-foo" {
 
   primary_name   = "example-primary"
   secondary_name = "example-secondary"
-
-  tags = {
-    app = "example"
-    env = "production"
-  }
 }
 ```
 

--- a/primary.tf
+++ b/primary.tf
@@ -5,7 +5,7 @@ resource "aws_s3_bucket" "primary" {
 
   force_destroy = var.force_destroy
 
-  tags = var.tags
+  tags = merge(var.default_tags, var.primary_s3_bucket_tags)
 }
 
 resource "aws_s3_bucket_versioning" "primary" {

--- a/secondary.tf
+++ b/secondary.tf
@@ -5,7 +5,7 @@ resource "aws_s3_bucket" "secondary" {
 
   force_destroy = var.force_destroy
 
-  tags = var.tags
+  tags = merge(var.default_tags, var.secondary_s3_bucket_tags)
 }
 
 resource "aws_s3_bucket_versioning" "secondary" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,12 @@
+variable "default_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
+}
+
 variable "force_destroy" {
   type    = string
   default = false
@@ -17,6 +26,15 @@ Name of bucket in created via the `aws.primary` AWS provider.
 EOS
 }
 
+variable "primary_s3_bucket_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the primary S3 bucket.
+EOS
+}
+
 variable "secondary_name" {
   type = string
 
@@ -25,11 +43,11 @@ Name of bucket in created via the `aws.secondary` AWS provider.
 EOS
 }
 
-variable "tags" {
+variable "secondary_s3_bucket_tags" {
   type    = map(string)
   default = {}
 
   description = <<EOS
-Tags to be assigned to the buckets.
+Map of tags assigned to the secondary S3 bucket.
 EOS
 }


### PR DESCRIPTION
Breaking change: Renaming `var.tags` to `var.default_tag` in order to make it clearer that those are tags are applied to all AWS resources.