### PR TITLE
Breaking change: Rename `var.tags` to `var.default_tags`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,6 @@ module "s3-backups-foo" {
 
   primary_name   = "example-primary"
   secondary_name = "example-secondary"
-
-  tags = {
-    app = "example"
-    env = "production"
-  }
 }
 ```
 

--- a/primary.tf
+++ b/primary.tf
@@ -5,7 +5,7 @@ resource "aws_s3_bucket" "primary" {
 
   force_destroy = var.force_destroy
 
-  tags = var.tags
+  tags = var.default_tags
 }
 
 resource "aws_s3_bucket_versioning" "primary" {

--- a/secondary.tf
+++ b/secondary.tf
@@ -5,7 +5,7 @@ resource "aws_s3_bucket" "secondary" {
 
   force_destroy = var.force_destroy
 
-  tags = var.tags
+  tags = var.default_tags
 }
 
 resource "aws_s3_bucket_versioning" "secondary" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,12 @@
+variable "default_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
+}
+
 variable "force_destroy" {
   type    = string
   default = false
@@ -22,14 +31,5 @@ variable "secondary_name" {
 
   description = <<EOS
 Name of bucket in created via the `aws.secondary` AWS provider.
-EOS
-}
-
-variable "tags" {
-  type    = map(string)
-  default = {}
-
-  description = <<EOS
-Map of tags assigned to all AWS resources created by this module.
 EOS
 }


### PR DESCRIPTION
This change is done to make it more clear, that tags specified via this attribute will be assigned to all AWS resources created by this module.

Also drop this attribute from the usage example in the `README.md`, as this attribute is rather for edge cases, as default tags typically specified via the `default_tags` block of the AWS provider.